### PR TITLE
test(auth,users): mocks p/ PATCH/DELETE /me; refatora teste de integr…

### DIFF
--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,7 +1,7 @@
 import uuid
 from unittest.mock import MagicMock, patch
 from schemas.user_schemas import UserSignUp, UserSignIn
-from utils.security import get_password_hash, decode_access_token  
+from utils.security import get_password_hash, decode_access_token
 from models.models import User
 from tests.tests_utils import make_client
 
@@ -13,10 +13,9 @@ API_PREFIX = "/api/v1"
 # Teste 1: create_user hash password
 @patch("services.user_service.get_password_hash")
 def test_create_user_hash_password(mock_get_password_hash):
-    
+
     mock_get_password_hash.return_value = "hashed_senha"
 
-    
     user_in = UserSignUp(
         name="Teste",
         email="teste@example.com",
@@ -25,11 +24,8 @@ def test_create_user_hash_password(mock_get_password_hash):
         password="Senha123!",
     )
 
-   
     mock_db = MagicMock()
-    mock_db.query.return_value.filter.return_value.first.return_value = (
-        None  
-    )
+    mock_db.query.return_value.filter.return_value.first.return_value = None
 
     from services.user_service import create_user
 
@@ -39,14 +35,12 @@ def test_create_user_hash_password(mock_get_password_hash):
     assert user.hashed_password == "hashed_senha"
 
 
-
 # Teste 2: authenticate invalid password
 @patch("services.user_service.verify_password")
 def test_authenticate_invalid_password(mock_verify):
     mock_verify.return_value = False
 
-   
-    from models.models import User 
+    from models.models import User
 
     mock_user = User(
         id=uuid.uuid4(),
@@ -59,7 +53,6 @@ def test_authenticate_invalid_password(mock_verify):
         is_admin=False,
     )
 
-   
     mock_db = MagicMock()
     mock_db.query.return_value.filter.return_value.first.return_value = mock_user
 
@@ -68,6 +61,38 @@ def test_authenticate_invalid_password(mock_verify):
     user = authenticate(mock_db, email="teste@example.com", password="SenhaErrada123!")
     assert user is None
 
+
+# Teste 3: authenticate valid password
+@patch("services.user_service.verify_password")
+def test_authenticate_valid_password(mock_verify):
+    mock_verify.return_value = True  # senha válida
+
+    from models.models import User
+    import uuid
+
+    mock_user = User(
+        id=uuid.uuid4(),
+        name="Teste",
+        email="teste@example.com",
+        cpf="12345678901",
+        phone="999999999",
+        hashed_password="hashed_senha",
+        is_active=True,
+        is_admin=False,
+    )
+
+    # Simula usuário existente no banco
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+    from services.user_service import authenticate
+
+    # Senha fornecida correta
+    user = authenticate(mock_db, email="teste@example.com", password="Senha123!")
+
+    # Agora deve autenticar com sucesso e retornar o usuário
+    assert user is not None
+    assert user.email == "teste@example.com"
 
 
 # Teste 3: create & decode access token
@@ -78,7 +103,6 @@ def test_create_and_decode_access_token():
     token = create_access_token(subject=str(user_id))
     decoded = decode_access_token(token)
     assert decoded == str(user_id)
-
 
 
 # Teste 4: rota /token integração
@@ -101,7 +125,6 @@ def test_token_route_integration(client, db_session):
     db_session.add(user)
     db_session.commit()
 
-    
     resp = client.post(
         "/api/v1/users/token",
         data={"username": user.email, "password": raw_password},
@@ -115,10 +138,8 @@ def test_token_route_integration(client, db_session):
     assert decoded == str(user.id) or decoded.get("sub") == str(user.id)
 
 
-
 def test_update_me_route_success():
     client = make_client()
-
 
     with patch("routes.user_routes.update_user_me") as mock_update:
         fake_id = uuid.uuid4()
@@ -147,7 +168,6 @@ def test_update_me_route_success():
         assert data["name"] == "Jane Doe"
         assert data["email"] == "jane@example.com"
 
-       
         args, _ = mock_update.call_args
         assert len(args) == 3
         assert getattr(args[1], "email", None) == "auth@example.com"
@@ -156,11 +176,11 @@ def test_update_me_route_success():
 def test_delete_me_route_soft_default_204():
     client = make_client()
 
-   
-    with patch("routes.user_routes.deactivate_user_me") as mock_soft, \
-         patch("routes.user_routes.hard_delete_user_me") as mock_hard:
+    with patch("routes.user_routes.deactivate_user_me") as mock_soft, patch(
+        "routes.user_routes.hard_delete_user_me"
+    ) as mock_hard:
 
-        r = client.delete(f"{API_PREFIX}/users/me") 
+        r = client.delete(f"{API_PREFIX}/users/me")
         assert r.status_code == 204, r.text
 
         mock_soft.assert_called_once()

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -1,0 +1,40 @@
+# tests/testutils.py
+import uuid
+from types import SimpleNamespace
+from importlib import import_module
+from unittest.mock import MagicMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+def make_client(
+    routes_module: str = "routes.user_routes",  # ajuste se o caminho for outro
+    api_prefix: str = "/api/v1",
+) -> TestClient:
+    ur = import_module(routes_module)
+    user_router = getattr(ur, "user_router")
+    get_db = getattr(ur, "get_db")
+    get_current_user = getattr(ur, "get_current_user")
+
+    app = FastAPI()
+    app.include_router(user_router, prefix=api_prefix)
+
+    # DB mock (não usamos de verdade porque patchamos os services)
+    def _override_get_db():
+        yield MagicMock()
+
+    # Usuário autenticado "realista" para não quebrar validadores (cpf string de 11 dígitos)
+    def _override_get_current_user():
+        return SimpleNamespace(
+            id=uuid.uuid4(),
+            is_active=True,
+            name="Auth User",
+            email="auth@example.com",
+            phone=None,
+            avatar=None,
+            cpf="12345678901",
+        )
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+
+    return TestClient(app)


### PR DESCRIPTION
…ação /signin

- Cria helper tests/testutils.py com make_client(...) e overrides de get_db/get_current_user
- Adiciona testes unitários (mock) das rotas:
  - PATCH /api/v1/users/me → 200; valida campos públicos e chamada de update_user_me(db, user, payload)
  - DELETE /api/v1/users/me (soft default) → 204; verifica chamada de deactivate_user_me e não chamada de hard_delete_user_me
- Corrige alvo dos patches para routes.user_routes.* (import local nas rotas)
- Ajusta mock de current_user com cpf válido (11 dígitos) para satisfazer validadores do schema
- Refatora teste de integração do login:
  - Usa prefixo /api/v1
  - (Quando aplicável) testa /users/token (OAuth2) com form x-www-form-urlencoded (username/password)
  - Valida token_type=bearer e decodificação do access_token